### PR TITLE
Fix empty channels

### DIFF
--- a/resources/lib/invidious_api.py
+++ b/resources/lib/invidious_api.py
@@ -84,6 +84,10 @@ class InvidiousAPIClient:
 
     def parse_response(self, response):
         data = response.json()
+        
+        # If a channel is opened, the videos are packaged in a dict entry "videos"
+        if "videos" in data:
+            data = data["videos"]
 
         for item in data:
             if item["type"] == "video":


### PR DESCRIPTION
I had the problem of channel being empty. This happens for channels in search results as well as followed channels. 

By studying the response of a invidious instance I found that it packages the videos into a JSON object "videos" and thus this changes should be a simple fix.